### PR TITLE
Fetch embeddings lazily and embeddings count

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ print(f"CRS: {crs}")  # Coordinate reference system from landmask
 
 # Method 2: Fetch all tiles in a bounding box
 bbox = (-0.2, 51.4, 0.1, 51.6)  # (min_lon, min_lat, max_lon, max_lat)
-embeddings = gt.fetch_embeddings(bbox, year=2024)
+embeddings = gt.fetch_embeddings_lazy(bbox, year=2024)
 
 for tile_lon, tile_lat, embedding_array, crs, transform in embeddings:
     print(f"Tile ({tile_lat}, {tile_lon}): {embedding_array.shape}")
@@ -241,7 +241,7 @@ files = gt.export_embedding_geotiffs(
 
 ```python
 # Fetch and process embeddings directly
-embeddings = gt.fetch_embeddings(bbox, year=2024)
+embeddings = gt.fetch_embeddings_lazy(bbox, year=2024)
 
 for lon, lat, embedding, crs, transform in embeddings:
     # Compute statistics

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ print(f"CRS: {crs}")  # Coordinate reference system from landmask
 
 # Method 2: Fetch all tiles in a bounding box
 bbox = (-0.2, 51.4, 0.1, 51.6)  # (min_lon, min_lat, max_lon, max_lat)
-embeddings = gt.fetch_embeddings_lazy(bbox, year=2024)
+embeddings = gt.fetch_embeddings(bbox, year=2024)
 
 for tile_lon, tile_lat, embedding_array, crs, transform in embeddings:
     print(f"Tile ({tile_lat}, {tile_lon}): {embedding_array.shape}")
@@ -241,7 +241,7 @@ files = gt.export_embedding_geotiffs(
 
 ```python
 # Fetch and process embeddings directly
-embeddings = gt.fetch_embeddings_lazy(bbox, year=2024)
+embeddings = gt.fetch_embeddings(bbox, year=2024)
 
 for lon, lat, embedding, crs, transform in embeddings:
     # Compute statistics

--- a/geotessera/core.py
+++ b/geotessera/core.py
@@ -73,7 +73,7 @@ class GeoTessera:
             return len(tiles)
 
     # returns a generator
-    def fetch_embeddings_lazy(
+    def fetch_embeddings(
         self,
         bbox: Tuple[float, float, float, float],
         year: int = 2024,
@@ -145,34 +145,7 @@ class GeoTessera:
                     )
                 continue
 
-        return None
-
-    def fetch_embeddings(
-        self,
-        bbox: Tuple[float, float, float, float],
-        year: int = 2024,
-        progress_callback: Optional[callable] = None,
-    ) -> List[Tuple[float, float, np.ndarray, object, object]]:
-        """Eagerly fetch all embedding tiles within a bounding box with CRS information.
-        For large areas, consider using fetch_embeddings_lazy() instead.
-
-        Args:
-            bbox: Bounding box as (min_lon, min_lat, max_lon, max_lat)
-            year: Year of embeddings to download
-            progress_callback: Optional callback function(current, total) for progress tracking
-
-        Returns:
-            List of (tile_lon, tile_lat, embedding_array, crs, transform) tuples where:
-            - tile_lon: Tile center longitude
-            - tile_lat: Tile center latitude
-            - embedding_array: shape (H, W, 128) with dequantized values
-            - crs: CRS object from rasterio (coordinate reference system)
-            - transform: Affine transform from rasterio
-        """
-        
-        results = list(self.fetch_embeddings_lazy(bbox, year, progress_callback))
-
-        return results    
+        return None 
 
     def fetch_embedding(
         self,

--- a/geotessera/core.py
+++ b/geotessera/core.py
@@ -79,7 +79,8 @@ class GeoTessera:
         year: int = 2024,
         progress_callback: Optional[callable] = None,
     ) -> Generator[Tuple[float, float, np.ndarray, object, object], None, None]:
-        """Fetch all embedding tiles within a bounding box with CRS information.
+        """Lazily fetches all embedding tiles within a bounding box with CRS information.
+        Use as a generator to process tiles one at a time in a memory-efficient manner.
 
         Args:
             bbox: Bounding box as (min_lon, min_lat, max_lon, max_lat)
@@ -87,7 +88,7 @@ class GeoTessera:
             progress_callback: Optional callback function(current, total) for progress tracking
 
         Returns:
-            List of (tile_lon, tile_lat, embedding_array, crs, transform) tuples where:
+            Generator of (tile_lon, tile_lat, embedding_array, crs, transform) tuples where:
             - tile_lon: Tile center longitude
             - tile_lat: Tile center latitude
             - embedding_array: shape (H, W, 128) with dequantized values
@@ -152,7 +153,8 @@ class GeoTessera:
         year: int = 2024,
         progress_callback: Optional[callable] = None,
     ) -> List[Tuple[float, float, np.ndarray, object, object]]:
-        """Fetch all embedding tiles within a bounding box with CRS information.
+        """Eagerly fetch all embedding tiles within a bounding box with CRS information.
+        For large areas, consider using fetch_embeddings_lazy() instead.
 
         Args:
             bbox: Bounding box as (min_lon, min_lat, max_lon, max_lat)


### PR DESCRIPTION
Adds a `fetch_embeddings_lazy` method and changes `fetch_embeddings` to call that and eagerly convert to list.

Also adds `embeddings_count`, which is useful for displaying progress when working over large areas.

There are three test failures but I've noticed those tests also fail on trunk.

Resolves #32