### PR TITLE
Make `fetch_embeddings` return also tile count when `with_count=True`

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -132,9 +132,9 @@ Download and analyze multiple tiles for a region::
     bbox = (0.0, 52.0, 0.3, 52.2)  # (min_lon, min_lat, max_lon, max_lat)
     
     # Fetch all tiles in the region with projection info
-    tiles = gt.fetch_embeddings(bbox, year=2024)
+    tiles, num_tiles = gt.fetch_embeddings(bbox, year=2024, with_count=True)
     
-    print(f"Found {len(tiles)} tiles in the region")
+    print(f"Found {num_tiles} tiles in the region")
     
     # Analyze each tile
     tile_stats = []
@@ -341,8 +341,7 @@ When working with large regions, use CLI for efficient processing::
         """Process a large region without loading all tiles into memory."""
         
         # Get list of available tiles (metadata only)
-        tiles = gt.fetch_embeddings(bbox, year)
-        total_tiles = len(tiles)
+        tiles, total_tiles = gt.fetch_embeddings(bbox, year, with_count=True)
         
         print(f"Processing {total_tiles} tiles...")
         print("Consider using CLI: geotessera download + geotessera visualize for large regions")
@@ -635,7 +634,7 @@ Reduce dimensionality of the 128-channel embeddings::
     bbox = (-0.1, 51.9, 0.1, 52.1)  # Small region around Cambridge
     tiles = gt.fetch_embeddings(bbox, year=2024)
     
-    X_pca, pca, scaler, tile_info = perform_pca_analysis(tiles, n_components=5)
+    X_pca, pca, scaler, tile_info = perform_pca_analysis(list(tiles), n_components=5)
     
     # Visualize first two principal components
     plt.figure(figsize=(12, 5))

--- a/geotessera/cli.py
+++ b/geotessera/cli.py
@@ -832,10 +832,11 @@ def download(
             else:  # format == 'npy'
                 # Export as numpy arrays
                 # Fetch embeddings as numpy arrays
-                embeddings = gt.fetch_embeddings(
+                embeddings, num_embeddings = gt.fetch_embeddings(
                     bbox=bbox_coords,
                     year=year,
                     progress_callback=create_download_progress_callback(progress, task),
+                    with_count=True,
                 )
 
                 if not embeddings:
@@ -928,7 +929,7 @@ def download(
                     files.append(str(json_filepath))
 
                 rprint(
-                    f"\n[green]✅ SUCCESS: Exported {len(embeddings)} numpy arrays[/green]"
+                    f"\n[green]✅ SUCCESS: Exported {num_embeddings} numpy arrays[/green]"
                 )
                 rprint("   Landmask TIFF files downloaded for each tile")
                 rprint("   Comprehensive JSON metadata files created for each tile")

--- a/geotessera/core.py
+++ b/geotessera/core.py
@@ -78,7 +78,11 @@ class GeoTessera:
         bbox: Tuple[float, float, float, float],
         year: int = 2024,
         progress_callback: Optional[callable] = None,
-    ) -> Generator[Tuple[float, float, np.ndarray, object, object], None, None]:
+        with_count: bool = False,
+    ) -> Union[
+        Generator[Tuple[float, float, np.ndarray, object, object], None, None],
+        Tuple[Generator[Tuple[float, float, np.ndarray, object, object], None, None], int],
+    ]:
         """Lazily fetches all embedding tiles within a bounding box with CRS information.
         Use as a generator to process tiles one at a time in a memory-efficient manner.
 
@@ -86,14 +90,18 @@ class GeoTessera:
             bbox: Bounding box as (min_lon, min_lat, max_lon, max_lat)
             year: Year of embeddings to download
             progress_callback: Optional callback function(current, total) for progress tracking
+            with_count: If True, also return the number of embedding tiles
 
         Returns:
-            Generator of (tile_lon, tile_lat, embedding_array, crs, transform) tuples where:
-            - tile_lon: Tile center longitude
-            - tile_lat: Tile center latitude
-            - embedding_array: shape (H, W, 128) with dequantized values
-            - crs: CRS object from rasterio (coordinate reference system)
-            - transform: Affine transform from rasterio
+            - If with_count=False (default):
+                Generator of (tile_lon, tile_lat, embedding_array, crs, transform) tuples where:
+                    - tile_lon: Tile center longitude
+                    - tile_lat: Tile center latitude
+                    - embedding_array: shape (H, W, 128) with dequantized values
+                    - crs: CRS object from rasterio (coordinate reference system)
+                    - transform: Affine transform from rasterio
+            - If with_count=True: 
+                A (generator, count) tuple, where count is the number of embedding tiles.
         """
         # Load registry blocks for this region and get available tiles directly
         tiles_to_download = self.registry.load_blocks_for_region(bbox, year)
@@ -101,51 +109,55 @@ class GeoTessera:
         # Download each tile with progress tracking
         total_tiles = len(tiles_to_download)
 
-        for i, (tile_lon, tile_lat) in enumerate(tiles_to_download):
-            try:
-                # Create a sub-progress callback for this tile's downloads
-                def tile_progress_callback(
-                    current: int, total: int, status: str = None
-                ):
+        def generator():
+            for i, (tile_lon, tile_lat) in enumerate(tiles_to_download):
+                try:
+                    # Create a sub-progress callback for this tile's downloads
+                    def tile_progress_callback(
+                        current: int, total: int, status: str = None
+                    ):
+                        if progress_callback:
+                            # Map individual file progress to overall tile progress
+                            tile_progress = (
+                                i * 100 + (current / max(total, 1)) * 100
+                            ) / total_tiles
+                            tile_status = (
+                                f"Tile {i + 1}/{total_tiles}: {status}"
+                                if status
+                                else f"Fetching tile {i + 1}/{total_tiles}"
+                            )
+                            progress_callback(int(tile_progress), 100, tile_status)
+
+                    embedding, crs, transform = self.fetch_embedding(
+                        tile_lon, tile_lat, year, tile_progress_callback
+                    )
+
+                    yield tile_lon, tile_lat, embedding, crs, transform
+
+                    # Update progress for completed tile
                     if progress_callback:
-                        # Map individual file progress to overall tile progress
-                        tile_progress = (
-                            i * 100 + (current / max(total, 1)) * 100
-                        ) / total_tiles
-                        tile_status = (
-                            f"Tile {i + 1}/{total_tiles}: {status}"
-                            if status
-                            else f"Fetching tile {i + 1}/{total_tiles}"
+                        progress_callback(
+                            (i + 1) * 100 // total_tiles,
+                            100,
+                            f"Completed tile {i + 1}/{total_tiles}",
                         )
-                        progress_callback(int(tile_progress), 100, tile_status)
 
-                embedding, crs, transform = self.fetch_embedding(
-                    tile_lon, tile_lat, year, tile_progress_callback
-                )
-
-                yield tile_lon, tile_lat, embedding, crs, transform
-
-                # Update progress for completed tile
-                if progress_callback:
-                    progress_callback(
-                        (i + 1) * 100 // total_tiles,
-                        100,
-                        f"Completed tile {i + 1}/{total_tiles}",
+                except Exception as e:
+                    print(
+                        f"Warning: Failed to download tile ({tile_lat:.2f}, {tile_lon:.2f}): {e}"
                     )
+                    if progress_callback:
+                        progress_callback(
+                            (i + 1) * 100 // total_tiles,
+                            100,
+                            f"Failed tile {i + 1}/{total_tiles}",
+                        )
+                    continue
 
-            except Exception as e:
-                print(
-                    f"Warning: Failed to download tile ({tile_lat:.2f}, {tile_lon:.2f}): {e}"
-                )
-                if progress_callback:
-                    progress_callback(
-                        (i + 1) * 100 // total_tiles,
-                        100,
-                        f"Failed tile {i + 1}/{total_tiles}",
-                    )
-                continue
-
-        return None 
+        if with_count:
+            return generator(), total_tiles
+        else:
+            return generator()
 
     def fetch_embedding(
         self,
@@ -459,7 +471,7 @@ class GeoTessera:
         if progress_callback:
             progress_callback(0, 100, "Loading registry blocks...")
 
-        tiles = self.fetch_embeddings(bbox, year, fetch_progress_callback)
+        tiles, total_tiles = self.fetch_embeddings(bbox, year, fetch_progress_callback, with_count=True)
 
         if not tiles:
             print("No tiles found in bounding box")
@@ -467,11 +479,10 @@ class GeoTessera:
 
         if progress_callback:
             progress_callback(
-                50, 100, f"Fetched {len(tiles)} tiles, starting GeoTIFF export..."
+                50, 100, f"Fetched {total_tiles} tiles, starting GeoTIFF export..."
             )
 
         created_files = []
-        total_tiles = len(tiles)
 
         # Sequential GeoTIFF writing
         for i, (tile_lon, tile_lat, embedding, crs, transform) in enumerate(tiles):


### PR DESCRIPTION
The PR [Fetch embeddings lazily and embeddings count #35](https://github.com/ucam-eo/geotessera/pull/35) which changed the return value of `fetch_embeddings()` from a list to a generator, caused other code to break that calls the `fetch_embeddings` function and tries to get the len of the return value. Generators don't have a len, resulting in `TypeError: object of type 'generator' has no len()`, see issue [Test failures #38](https://github.com/ucam-eo/geotessera/issues/38).

The present PR adds a boolean `with_count` argument to `fetch_embeddings()` that optionally causes the function to return `(generator, count)` instead of just the generator. All the other code in the repo is modified to use that mechanism to obtain the count instead of using len. Also the PCA example is changed to convert the generator to a list as needed by PCA.

Some doubts: While avoiding getting `self.registry.load_blocks_for_region()` called twice by both `fetch_embeddings()` and `embeddings_count()`, admittedly the present PR makes `fetch_embeddings()` a bit messier. Perhaps it would be better to expose `self.registry`'s `load_blocks_for_region()` to the user and allow them to pass the returned list (the len of which they can get) as argument to `fetch_embeddings()`. This would also remove the need to have `embeddings_count()` and would open the possibility to include year for each tile in tile lists in addition to lon, lat. **I'll close this PR in favor of the alternative approach** and will maybe work on it.