### PR TITLE
Expose registry for tile selection outside `fetch_embeddings()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,10 @@ print(f"CRS: {crs}")  # Coordinate reference system from landmask
 
 # Method 2: Fetch all tiles in a bounding box
 bbox = (-0.2, 51.4, 0.1, 51.6)  # (min_lon, min_lat, max_lon, max_lat)
-embeddings = gt.fetch_embeddings(bbox, year=2024)
+tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+embeddings = gt.fetch_embeddings(tiles_to_fetch)
 
-for tile_lon, tile_lat, embedding_array, crs, transform in embeddings:
+for year, tile_lon, tile_lat, embedding_array, crs, transform in embeddings:
     print(f"Tile ({tile_lat}, {tile_lon}): {embedding_array.shape}")
 ```
 
@@ -241,7 +242,8 @@ files = gt.export_embedding_geotiffs(
 
 ```python
 # Fetch and process embeddings directly
-embeddings = gt.fetch_embeddings(bbox, year=2024)
+tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+embeddings = gt.fetch_embeddings(tiles_to_fetch)
 
 for lon, lat, embedding, crs, transform in embeddings:
     # Compute statistics

--- a/docs/geotessera.rst
+++ b/docs/geotessera.rst
@@ -102,9 +102,10 @@ Initialize and fetch embeddings::
     
     # Fetch region with projection info
     bbox = (-0.2, 51.4, 0.1, 51.6)
-    tiles = gt.fetch_embeddings(bbox, year=2024)
+    tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    tiles = gt.fetch_embeddings(tiles_to_fetch)
     
-    for tile_lon, tile_lat, embedding, crs, transform in tiles:
+    for year, tile_lon, tile_lat, embedding, crs, transform in tiles:
         print(f"Tile ({tile_lon}, {tile_lat}): {embedding.shape}, CRS: {crs}")
 
 Export to GeoTIFF
@@ -114,16 +115,14 @@ Export embeddings for GIS use with preserved projections::
 
     # Export all bands with native UTM projections
     files = gt.export_embedding_geotiffs(
-        bbox=bbox,
+        files_to_fetch,
         output_dir="./output",
-        year=2024
     )
     
     # Export specific bands
     rgb_files = gt.export_embedding_geotiffs(
-        bbox=bbox,
+        files_to_fetch,
         output_dir="./rgb_output", 
-        year=2024,
         bands=[0, 1, 2]  # Each tile preserves its native UTM projection
     )
     

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,9 +84,10 @@ Python API usage::
     
     # Method 2: Fetch all tiles in a bounding box
     bbox = (-0.2, 51.4, 0.1, 51.6)  # (min_lon, min_lat, max_lon, max_lat)
-    tiles = gt.fetch_embeddings(bbox, year=2024)
+    tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    tiles = gt.fetch_embeddings(tiles_to_fetch)
     
-    for tile_lon, tile_lat, embedding, crs, transform in tiles:
+    for year, tile_lon, tile_lat, embedding, crs, transform in tiles:
         print(f"Tile ({tile_lon}, {tile_lat}): {embedding.shape}")
     
     # Export as GeoTIFF files with preserved UTM projections

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -162,9 +162,10 @@ Fetch a single embedding tile with CRS information::
 Fetch multiple tiles in a bounding box::
 
     bbox = (-0.2, 51.4, 0.1, 51.6)  # (min_lon, min_lat, max_lon, max_lat)
-    tiles = gt.fetch_embeddings(bbox, year=2024)
+    tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    tiles = gt.fetch_embeddings(tiles_to_fetch)
     
-    for tile_lon, tile_lat, embedding_array, crs, transform in tiles:
+    for year, tile_lon, tile_lat, embedding_array, crs, transform in tiles:
         print(f"Tile ({tile_lon}, {tile_lat}): {embedding_array.shape}")
         print(f"  CRS: {crs}")
         
@@ -297,7 +298,8 @@ Complete analysis workflow::
     bbox = (-0.15, 52.15, 0.0, 52.25)  # Cambridge area
     
     # Fetch embeddings
-    embeddings = gt.fetch_embeddings(bbox, year=2024)
+    tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    embeddings = gt.fetch_embeddings(tiles_to_fetch)
     
     # Analyze each tile
     results = []
@@ -354,7 +356,8 @@ Use both numpy and GeoTIFF formats in the same workflow::
     
     # Step 1: Analyze with numpy arrays
     print("Analyzing embeddings...")
-    tiles = gt.fetch_embeddings(bbox, year=2024)
+    tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    tiles = gt.fetch_embeddings(tiles_to_fetch)
     
     # Custom analysis to select interesting tiles
     selected_coords = []

--- a/geotessera/__init__.py
+++ b/geotessera/__init__.py
@@ -18,7 +18,8 @@ Simplified Usage:
     >>>
     >>> # Fetch embedding tiles in a bounding box
     >>> bbox = (-0.2, 51.4, 0.1, 51.6)  # London area
-    >>> tiles = gt.fetch_embeddings(bbox, year=2024)
+    >>> tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=bbox, year=2024)
+    >>> tiles = gt.fetch_embeddings(tiles_to_fetch)
     >>>
     >>> # Export as individual GeoTIFF files
     >>> files = gt.export_embedding_geotiffs(

--- a/geotessera/country.py
+++ b/geotessera/country.py
@@ -322,8 +322,8 @@ def get_country_bbox(
     return get_country_lookup(progress_callback).get_bbox(country_name)
 
 
-def get_country_tiles(country_name: str, year: int = 2024) -> List[Tuple[float, float]]:
-    """Get list of GeoTessera tile coordinates that intersect with country."""
+def get_country_tiles(country_name: str, year: int = 2024) -> List[Tuple[int, float, float]]:
+    """Get list of GeoTessera tile (year, tile_lon, tile_lat) tuples that intersect with country."""
     from .core import GeoTessera
 
     # Get country bounding box
@@ -332,6 +332,6 @@ def get_country_tiles(country_name: str, year: int = 2024) -> List[Tuple[float, 
 
     # Use existing registry to find tiles in the bounding box
     gt = GeoTessera()
-    tiles = gt.registry.load_blocks_for_region(bbox, year)
+    tiles = gt.registry.load_blocks_for_region(bounds=bbox, year=year)
 
     return tiles

--- a/geotessera/registry.py
+++ b/geotessera/registry.py
@@ -464,7 +464,7 @@ class Registry:
         2. Land mask fetcher for GeoTIFF files containing binary land/water
            masks and coordinate reference system metadata
 
-        Registry files are loaded lazily per year to improve performance.
+        Registry files are loaded lazily to improve performance.
         """
         cache_path = (
             self._cache_dir if self._cache_dir else pooch.os_cache("geotessera")
@@ -809,7 +809,7 @@ class Registry:
 
     def load_blocks_for_region(
         self, bounds: Tuple[float, float, float, float], year: int
-    ) -> List[Tuple[float, float]]:
+    ) -> List[Tuple[int, float, float]]:
         """Load only the registry blocks needed for a specific region and return available tiles.
 
         This is much more efficient than loading all blocks globally when only
@@ -820,7 +820,7 @@ class Registry:
             year: Year of embeddings to load
 
         Returns:
-            List of (tile_lon, tile_lat) tuples for tiles available in the region
+            List of (year, tile_lon, tile_lat) tuples for tiles available in the region
         """
         min_lon, min_lat, max_lon, max_lat = bounds
 
@@ -890,7 +890,7 @@ class Registry:
                 and tile_min_lat < max_lat
                 and tile_max_lat > min_lat
             ):
-                tiles_in_region.append((lon, lat))
+                tiles_in_region.append((year, lon, lat))
 
         return tiles_in_region
 

--- a/tests/test_dataset_version.py
+++ b/tests/test_dataset_version.py
@@ -73,7 +73,7 @@ class TestGeoTIFFMetadataTags:
         # Setup mocks
         mock_registry_instance = Mock()
         mock_registry_class.return_value = mock_registry_instance
-        mock_registry_instance.load_blocks_for_region.return_value = [(-0.15, 51.55)]
+        mock_registry_instance.load_blocks_for_region.return_value = [(2024, -0.15, 51.55)]
         mock_registry_instance.available_embeddings = [(2024, -0.15, 51.55)]
         mock_registry_instance.ensure_block_loaded.return_value = None
         mock_registry_instance.fetch.return_value = "/fake/path"
@@ -101,8 +101,9 @@ class TestGeoTIFFMetadataTags:
                         gt = GeoTessera(dataset_version="v2")
 
                         # Export tiles
+                        tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=(-0.1, 51.5, 0.0, 51.6), year=2024)
                         gt.export_embedding_geotiffs(
-                            bbox=(-0.1, 51.5, 0.0, 51.6), output_dir=temp_dir, year=2024
+                            tiles_to_fetch, output_dir=temp_dir
                         )
 
                         # Check that update_tags was called with correct metadata

--- a/tests/test_utm_projection_export.py
+++ b/tests/test_utm_projection_export.py
@@ -194,7 +194,7 @@ class TestUTMProjectionExportSimple:
         gt = GeoTessera()
 
         # Mock the embedding fetch system
-        gt.registry.load_blocks_for_region = Mock(return_value=[(51.55, -0.05)])
+        gt.registry.load_blocks_for_region = Mock(return_value=[(2024, 51.55, -0.05)])
         gt.registry.ensure_tile_block_loaded = Mock()
         gt.registry.fetch = Mock(return_value="/fake/path")
 
@@ -228,10 +228,10 @@ class TestUTMProjectionExportSimple:
 
                             with tempfile.TemporaryDirectory() as temp_dir:
                                 # Export tiles
+                                tiles_to_fetch = gt.registry.load_blocks_for_region(bounds=(-0.1, 51.5, 0.0, 51.6), year=2024)
                                 gt.export_embedding_geotiffs(
-                                    bbox=(-0.1, 51.5, 0.0, 51.6),
+                                    tiles_to_fetch,
                                     output_dir=temp_dir,
-                                    year=2024,
                                 )
 
                                 # Verify UTM projection was used


### PR DESCRIPTION
The PR [Fetch embeddings lazily and embeddings count #35](https://github.com/ucam-eo/geotessera/pull/35) which changed the return value of `fetch_embeddings()` from a list to a generator, caused other code to break that calls the `fetch_embeddings` function and tries to get the len of the return value. Generators don't have a len, resulting in `TypeError: object of type 'generator' has no len()`, see issue [Test failures #38](https://github.com/ucam-eo/geotessera/issues/38).

The present PR solves the problem with the following:
* Expose `registry` to the user as an attribute of `Geotessera`.
* The user can search for tiles with bounds and year using `registry.load_blocks_for_region()` that returns a list of (year, tile_lon, tile_lat) tuples.
* The len of the list is readily available.
* The list can be passed on to `fetch_embeddings()` which generates (year, tile_lon, tile_lat, embedding, crs, transform) tuples, to `export_embedding_geotiffs()`, and to `export_pca_geotiffs()` which returns a list of (year, tile_lon, tile_lat, pca_image, crs, transform, pca_info) tuples.

Including year in the tuples means that functions consuming lists/iterables containing them no longer need the year as an argument. This approach is flexible, allowing manipulation of tile selections by the user and the processing of arbitrary selections of tiles in (time, lon, lat) space.