### PR TITLE
ci: switch to non-retired mac runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # macos-13 is an intel runner, macos-14 is apple silicon
-        os: [ubuntu-latest, macos-13, macos-14]
+        os: [ubuntu-latest, macos-15-intel, macos-14]
         python-version: [3.11, 3.12, 3.13]
 
     steps:


### PR DESCRIPTION
Github has retired macos-13 runners, so switch to 14/15 now