### PR TITLE
Fix memory leak in GeoTIFF export and add resume capability

### DIFF
--- a/geotessera/cli.py
+++ b/geotessera/cli.py
@@ -1386,11 +1386,11 @@ def download(
 
                     if not filtered_tiles:
                         rprint(
-                            f"\n[green]{emoji('✅ ')}SUCCESS: All {len(tiles_to_fetch)} GeoTIFF(s) already exist[/green]"
+                            f"\n[green]{emoji('✅ ')}SUCCESS: All {len(tiles_to_fetch)} GeoTIFF files already exist[/green]"
                         )
                     else:
                         rprint(
-                            f"\n[green]{emoji('✅ ')}SUCCESS: Exported {len(files)} GeoTIFF(s)"
+                            f"\n[green]{emoji('✅ ')}SUCCESS: Exported {len(files)} GeoTIFF files"
                             + (f" ({skipped_files} skipped)" if skipped_files > 0 else "")
                             + "[/green]"
                         )

--- a/geotessera/cli.py
+++ b/geotessera/cli.py
@@ -29,6 +29,7 @@ from geotessera.registry import (
     tile_from_world,
     tile_to_landmask_filename,
     tile_to_embedding_paths,
+    tile_to_geotiff_path,
 )
 from rich.progress import Progress, TaskID, BarColumn, TextColumn, TimeRemainingColumn
 from rich.table import Table
@@ -1353,20 +1354,46 @@ def download(
 
             match format:
                 case "tiff":
-                    # Export as GeoTIFF files
-                    files = gt.export_embedding_geotiffs(
-                        tiles_to_fetch,
-                        output_dir=output,
-                        bands=bands_list,
-                        compress=compress,
-                        progress_callback=create_download_progress_callback(
-                            progress, task
-                        ),
-                    )
+                    skipped_files = 0
+                    filtered_tiles = []
+                    for tile_year, tile_lon, tile_lat in tiles_to_fetch:
+                        geotiff_path = (
+                            output
+                            / EMBEDDINGS_DIR_NAME
+                            / tile_to_geotiff_path(tile_lon, tile_lat, tile_year)
+                        )
+                        if geotiff_path.exists():
+                            skipped_files += 1
+                        else:
+                            filtered_tiles.append((tile_year, tile_lon, tile_lat))
 
-                    rprint(
-                        f"\n[green]{emoji('✅ ')}SUCCESS: Exported {len(files)} GeoTIFF files[/green]"
-                    )
+                    total_tiles = len(filtered_tiles)
+                    progress.update(task, total=max(total_tiles, 1), completed=0)
+
+                    if not filtered_tiles:
+                        progress.update(task, completed=1, status="Complete")
+                        files = []
+                    else:
+                        files = gt.export_embedding_geotiffs(
+                            filtered_tiles,
+                            output_dir=output,
+                            bands=bands_list,
+                            compress=compress,
+                            progress_callback=create_download_progress_callback(
+                                progress, task
+                            ),
+                        )
+
+                    if not filtered_tiles:
+                        rprint(
+                            f"\n[green]{emoji('✅ ')}SUCCESS: All {len(tiles_to_fetch)} GeoTIFF(s) already exist[/green]"
+                        )
+                    else:
+                        rprint(
+                            f"\n[green]{emoji('✅ ')}SUCCESS: Exported {len(files)} GeoTIFF(s)"
+                            + (f" ({skipped_files} skipped)" if skipped_files > 0 else "")
+                            + "[/green]"
+                        )
                     rprint(
                         "   Each file preserves its native UTM projection from landmask tiles"
                     )

--- a/geotessera/core.py
+++ b/geotessera/core.py
@@ -1598,37 +1598,26 @@ class GeoTessera:
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        # Create a wrapper callback to handle two-phase progress
-        def fetch_progress_callback(current: int, total: int, status: str = None):
-            # Phase 1: Fetching tiles (0-50% of total progress)
-            overall_progress = int((current / total) * 50)
-            display_status = status or f"Fetching tile {current}/{total}"
-            progress_callback(overall_progress, 100, display_status)
-
         # Fetch tiles with progress tracking
         if progress_callback:
-            progress_callback(0, 100, "Loading registry blocks...")
+            progress_callback(0, 100, "Starting download...")
 
-        tiles = list(
-            self.fetch_embeddings(
-                tiles_to_fetch, fetch_progress_callback if progress_callback else None
-            )
-        )
-        if progress_callback:
-            total_tiles = len(tiles_to_fetch)
+        tiles_to_fetch = list(tiles_to_fetch)
+        total_tiles = len(tiles_to_fetch)
 
-        if not tiles:
-            self.logger.warning("No tiles found in bounding box")
+        if total_tiles == 0:
+            self.logger.info("No tiles to export")
+            if progress_callback:
+                progress_callback(100, 100, "No tiles to export")
             return []
 
-        if progress_callback:
-            progress_callback(
-                50, 100, f"Fetched {total_tiles} tiles, starting GeoTIFF export..."
-            )
+        tiles = self.fetch_embeddings(
+            tiles_to_fetch, progress_callback if progress_callback else None
+        )
 
         created_files = []
 
-        # Sequential GeoTIFF writing
+        # Sequential fetching of tile data and writing GeoTIFFs
         for i, (year, tile_lon, tile_lat, embedding, crs, transform) in enumerate(
             tiles
         ):
@@ -1636,13 +1625,6 @@ class GeoTessera:
             geotiff_rel_path = tile_to_geotiff_path(tile_lon, tile_lat, year)
             output_path = output_dir / EMBEDDINGS_DIR_NAME / geotiff_rel_path
             output_path.parent.mkdir(parents=True, exist_ok=True)
-
-            # Update progress to show we're starting this file
-            if progress_callback:
-                export_progress = int(50 + (i / total_tiles) * 50)
-                progress_callback(
-                    export_progress, 100, f"Creating {output_path.name}..."
-                )
 
             # Select bands
             if bands is not None:
@@ -1697,20 +1679,19 @@ class GeoTessera:
 
             # Update progress for GeoTIFF export phase
             if progress_callback:
-                # Phase 2: Exporting GeoTIFFs (50-100% of total progress)
-                export_progress = int(50 + ((i + 1) / total_tiles) * 50)
                 progress_callback(
-                    export_progress,
-                    100,
+                    i + 1,
+                    total_tiles,
                     f"Exported {output_path.name} ({i + 1}/{total_tiles})",
                 )
 
         if progress_callback:
             progress_callback(
-                100, 100, f"Completed! Exported {len(created_files)} GeoTIFF files"
+                total_tiles, total_tiles,
+                f"Completed! Exported {len(created_files)} GeoTIFF file(s)"
             )
 
-        self.logger.info(f"Exported {len(created_files)} GeoTIFF files to {output_dir}")
+        self.logger.info(f"Exported {len(created_files)} GeoTIFF file(s) to {output_dir}")
         return created_files
 
     def merge_geotiffs_to_mosaic(


### PR DESCRIPTION
## Summary

Fixes a memory leak when downloading GeoTIFFs (closes #137) and aligns the GeoTIFF
download behaviour and CLI output with the existing NPY download logic.

## Changes

### `core.py` — `export_embedding_geotiffs`
- Changed `fetch_embeddings()` from materializing all tiles into a list
  to using it as a lazy generator, fixing the memory leak when downloading
  large regions
- Adjusted the two-phase (0–50% fetch / 50–100% write) progress model accordingly to a single unified per-tile progress callback, matching the now-interleaved fetch-and-write flow

### `cli.py` — `download` command, `tiff` case
- Added `tile_to_geotiff_path` to registry imports
- Added skip-existing filter before calling `export_embedding_geotiffs`,
  mirroring the NPY resume capability
- Progress bar total is updated after filtering to reflect only remaining
  tiles, so the bar accurately represents work still to be done
- Aligned success/skip summary messages with NPY format wording