### PR TITLE
Ensure geometry file is in lat/lon when calculating bbox

### DIFF
--- a/geotessera/visualization.py
+++ b/geotessera/visualization.py
@@ -737,6 +737,7 @@ def calculate_bbox_from_file(
         Bounding box as (min_lon, min_lat, max_lon, max_lat)
     """
     gdf = gpd.read_file(filepath)
+    gdf = gdf.to_crs("EPSG:4326")  # Ensure it's in lat/lon
     bounds = gdf.total_bounds  # [minx, miny, maxx, maxy]
     return tuple(bounds)
 


### PR DESCRIPTION
Hi again, 
I noticed that download doesn't work if the provided geometry file is not projected in EPSG 4326. As far as I can tell the bbox is always expected to be in lat/lon so forcing reprojection here makes sense to me. Hope I didn't miss anything that would clash with this change.  