### PR TITLE
Allow generators like zip for coordinate lists.

### DIFF
--- a/geotessera/core.py
+++ b/geotessera/core.py
@@ -1030,8 +1030,8 @@ class GeoTessera:
             List of (lon, lat) tuples
         """
         # Handle list of tuples (most common case)
-        if isinstance(points, list):
-            return points
+        if isinstance(points, Iterable):
+            return list(points)
 
         # Handle GeoJSON FeatureCollection
         if isinstance(points, dict):


### PR DESCRIPTION
In Python it's common to have generators for lists, and in particular `zip` in Python produces a generator, not a concrete list.

I had the following code which was blowing up because GeoTessera demanded a list type:

```python
    transformer = Transformer.from_crs("EPSG:3006", "EPSG:4326", always_xy=True)
    lons, lats = transformer.transform(projected_cols, projected_rows)
    coords = zip(lons, lats)

    embeddings = gt.sample_embeddings_at_points(coords, year=YEAR)
```

This threw an exception with:

```
ValueError: points must be a list of (lon, lat) tuples, GeoJSON FeatureCollection, or GeoPandas GeoDataFrame
```

I believe the correct type to use here is `Iterable`: https://docs.python.org/3/glossary.html#term-iterable