### PR TITLE
zarr: compress x/y/time arrays to save client download time

### DIFF
--- a/geotessera/zarr.py
+++ b/geotessera/zarr.py
@@ -1010,7 +1010,7 @@ def _create_zone_group(
             shape=data.shape,
             dtype=data.dtype,
             fill_value=0,
-            compressors=None,
+            compressors=BloscCodec(cname="zstd", clevel=3),
             dimension_names=[dim],
         )
         store[name][:] = data


### PR DESCRIPTION
noticed by @aneeshnaik and @mtelvers