### PR TITLE
`GeoTesseraZarr.read_patch(lon, lat, year, size_px)` returns a patch centred on a point

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,13 @@ need no landmask.
 
 ### New Features
 
+- A new `GeoTesseraZarr.read_patch(lon, lat, year, size_px)` returns a
+  `(size_px, size_px, 128)` patch centred on a point.  A patch within one
+  UTM zone is sliced from the native grid unresampled; one crossing a zone
+  boundary is merged onto a patch-centred transverse Mercator grid with
+  nearest-neighbour resampling, and `dst_crs=` pins any other output CRS.
+  `read_region` now warns when its bbox crosses a zone boundary. (@avsm @aneeshnaik)
+
 - The hosted Zarr store is available at
   `https://data.source.coop/tessera/tessera/zarr/v1`. `GeoTesseraZarr()`
   streams from it with no downloads and no configuration (@avsm)

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ mosaic, transform, crs = gt.read_region(
 )
 print(f"Mosaic shape: {mosaic.shape}")
 
+# Read a fixed-size patch centred on a point, whatever zones it spans
+patch, transform, crs = gt.read_patch(0.0, 52.2, year=2025, size_px=512)
+print(f"Patch shape: {patch.shape}")  # (512, 512, 128)
+
 # Work with individual UTM zones via xarray
 ds = gt.open_zone(lon=0.15)
 print(ds)

--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -561,6 +561,8 @@ front, rather than per call.
   embeddings at lon/lat coordinates across zones
 - **Region reading**: ``read_region()`` takes a lon/lat bbox and returns the
   mosaic on the zone's native UTM grid, with its transform and CRS
+- **Patch reading**: ``read_patch()`` returns a fixed-size square centred
+  on a point, merged across UTM zones when the patch crosses a boundary
 - **Zone access**: ``open_zone()`` returns an xarray Dataset with a
   ``.tessera`` accessor for direct manipulation
 - **Diagnostics**: ``probe()`` returns ``(embedding, status)``, the status
@@ -1090,6 +1092,8 @@ group. The store automatically routes geographic queries to the correct zone::
   embeddings at specific coordinates across zones
 - **Region reading**: ``read_region()`` for loading rectangular areas as
   mosaics with CRS and transform metadata
+- **Patch reading**: ``read_patch()`` for fixed-size squares centred on a
+  point, merged across UTM zones when needed
 - **Zone access**: ``open_zone()`` returns an xarray Dataset with a
   ``.tessera`` accessor for direct manipulation
 - **Diagnostics**: ``probe()`` returns ``(embedding, status)``, the status

--- a/docs/geotessera.rst
+++ b/docs/geotessera.rst
@@ -83,6 +83,7 @@ Cloud-native access to Tessera embeddings via Zarr v3 format, with automatic UTM
 * :class:`~geotessera.store.GeoTesseraZarr` - Cloud-native Zarr store for streaming access without downloads
 * :meth:`~geotessera.store.GeoTesseraZarr.sample_points` - Sample embeddings at specific coordinates
 * :meth:`~geotessera.store.GeoTesseraZarr.read_region` - Read rectangular regions as mosaics
+* :meth:`~geotessera.store.GeoTesseraZarr.read_patch` - Read a fixed-size patch centred on a point, merged across UTM zones
 * :meth:`~geotessera.store.GeoTesseraZarr.open_zone` - Open UTM zone as xarray Dataset
 * :meth:`~geotessera.store.GeoTesseraZarr.probe` - Sample a point, reporting why when there is no value
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -459,6 +459,10 @@ store. This streams data directly from the cloud::
     )
     print(f"Mosaic shape: {mosaic.shape}")
 
+    # Read a fixed-size patch centred on a point, whatever zones it spans
+    patch, transform, crs = gt.read_patch(0.0, 52.2, year=2025, size_px=512)
+    print(f"Patch shape: {patch.shape}")  # (512, 512, 128)
+
     # Work with individual UTM zones via xarray
     ds = gt.open_zone(lon=0.15)
     print(ds)

--- a/geotessera/__init__.py
+++ b/geotessera/__init__.py
@@ -19,6 +19,9 @@ for point sampling and for regions you want as arrays::
     >>> # Read a bounding box — (H, W, 128) float32
     >>> mosaic, transform, crs = gt.read_region((-3.0, 53.4, -2.9, 53.5), year=2025)
 
+    >>> # Read a fixed-size patch centred on a point, whatever zones it spans
+    >>> patch, transform, crs = gt.read_patch(0.0, 52.2, year=2025, size_px=512)
+
     >>> # Tell open water apart from a gap in coverage
     >>> vec, status = gt.probe(-2.97, 53.44, year=2025)  # 'valid' | 'water' | ...
 

--- a/geotessera/store.py
+++ b/geotessera/store.py
@@ -26,6 +26,9 @@ Usage::
     X = gt.sample_points([(-2.97, 53.44), (-2.96, 53.43)], year=2025)
     mosaic, transform, crs = gt.read_region(bbox, year=2025)  # bbox in lon/lat
 
+    # A fixed-size patch centred on a point, merged across UTM zones
+    patch, transform, crs = gt.read_patch(0.0, 52.2, year=2025, size_px=512)
+
     # Direct zone access, in that zone's UTM
     ds = gt.open_zone(lon=-2.97)
     emb = ds.tessera.sample_at(500_000.0, 5_921_000.0, year=2025)
@@ -46,6 +49,7 @@ import rasterio.transform
 import xarray as xr
 import zarr
 from pyproj import Transformer
+from rasterio.warp import Resampling, reproject
 from rich.progress import track
 
 from .registry import zarr_store_url
@@ -162,6 +166,32 @@ def _seam_neighbours(lon: float) -> List[int]:
     if frac >= 6.0 - SEAM_DEGREES:
         out.append(1 if z == 60 else z + 1)
     return out
+
+
+def _patch_crs(lon: float, lat: float) -> str:
+    """A transverse Mercator CRS with its central meridian at *lon*.
+
+    UTM's projection, centred on the patch rather than on a 6-degree zone,
+    which keeps distortion small and symmetric whatever the patch spans.
+    """
+    y0 = 0 if lat >= 0 else 10000000
+    return (
+        f"+proj=tmerc +lat_0=0 +lon_0={lon:.8f} +k=0.9996 "
+        f"+x_0=500000 +y_0={y0} +datum=WGS84 +units=m +no_defs"
+    )
+
+
+def _zones_spanned(lons: List[float], centre_lon: float) -> List[int]:
+    """The contiguous run of UTM zones covering *lons*, walked the short
+    way round the ring so a patch on the antimeridian gets ``[60, 1]``."""
+    zc = _zone_for_lon(centre_lon)
+
+    def offset(z: int) -> int:
+        d = (z - zc) % 60
+        return d - 60 if d > 30 else d
+
+    offs = [offset(_zone_for_lon(lon)) for lon in lons]
+    return [(zc - 1 + o) % 60 + 1 for o in range(min(offs), max(offs) + 1)]
 
 
 def open_zone(
@@ -613,8 +643,19 @@ class GeoTesseraZarr:
         mosaic is in that zone's UTM, not in WGS84: the bbox is projected to
         pick the window, and the pixels come back on their native grid
         untouched.
+
+        A bbox crossing a zone boundary is served from the centre zone
+        alone; :meth:`read_patch` merges across zones.
         """
         z = _zone_for_lon((bbox[0] + bbox[2]) / 2)
+        edge_zones = _zones_spanned([bbox[0], bbox[2]], (bbox[0] + bbox[2]) / 2)
+        if len(edge_zones) > 1:
+            log.warning(
+                "read_region: bbox spans UTM zones %s; reading zone %d only — "
+                "use read_patch() to merge across zones",
+                edge_zones,
+                z,
+            )
         ds = self.open_zone(zone=z)
         zone_crs = ds.tessera.crs
 
@@ -632,3 +673,203 @@ class GeoTesseraZarr:
 
         mosaic, transform = ds.tessera.read_region(utm_bbox, year, progress=progress)
         return mosaic, transform, zone_crs
+
+    # -- Patch reading (cross-zone) ------------------------------------------
+
+    def read_patch(
+        self,
+        lon: float,
+        lat: float,
+        year: int,
+        size_px: int,
+        *,
+        dst_crs: Optional[str] = None,
+        resampling: str = "nearest",
+        progress: bool = False,
+    ) -> Tuple[np.ndarray, rasterio.transform.Affine, str]:
+        """Read a fixed-size square patch centred on a point.
+
+        Returns ``(patch, transform, crs)``.  The patch is exactly
+        ``(size_px, size_px, B)`` float32, NaN where the store holds
+        nothing; the point falls in pixel ``[size_px // 2, size_px // 2]``.
+
+        A patch within one UTM zone is sliced from that zone's grid
+        unresampled, in the zone's CRS.  A patch crossing a zone boundary
+        is merged onto a transverse Mercator grid centred on the patch,
+        relocating pixels whole with nearest-neighbour resampling; each
+        pixel comes from the zone owning its longitude, neighbours filling
+        gaps, as :meth:`sample_at` prefers.
+
+        Args:
+            lon: Patch centre longitude (WGS84).
+            lat: Patch centre latitude (WGS84).
+            year: Embedding year.
+            size_px: Patch width and height in pixels.
+            dst_crs: Output CRS, for pipelines that need every patch in
+                one CRS; forces the merge path even within one zone.
+            resampling: rasterio resampling name for the merge path.
+                Only the ``"nearest"`` default leaves vectors unblended.
+            progress: Show a progress bar while downloading.
+        """
+        if size_px <= 0:
+            raise ValueError(f"size_px must be positive, got {size_px}")
+
+        centre_ds = self.open_zone(lon=lon)
+        acc = centre_ds.tessera
+        px = acc.pixel_size
+        half = size_px * px / 2.0
+
+        ce, cn = _project(lon, lat, "EPSG:4326", acc.crs)
+        corner_lons = [
+            _project(ce + dx, cn + dy, acc.crs, "EPSG:4326")[0]
+            for dx in (-half, half)
+            for dy in (-half, half)
+        ]
+        zones = _zones_spanned(corner_lons, lon)
+
+        if dst_crs is None and len(zones) == 1:
+            return self._read_patch_native(centre_ds, ce, cn, year, size_px, progress)
+
+        target_crs = dst_crs or _patch_crs(lon, lat)
+        return self._read_patch_merged(
+            zones, target_crs, lon, lat, year, size_px, px, resampling, progress
+        )
+
+    def _read_patch_native(
+        self,
+        ds: xr.Dataset,
+        centre_e: float,
+        centre_n: float,
+        year: int,
+        size_px: int,
+        progress: bool,
+    ) -> Tuple[np.ndarray, rasterio.transform.Affine, str]:
+        """Slice a patch straight off one zone's grid, NaN-padded at edges."""
+        acc = ds.tessera
+        px = acc.pixel_size
+
+        # Off-grid pixels get a NaN scale, which dequantise() masks.
+        near = ds.sel(x=centre_e, y=centre_n, method="nearest")
+        offsets = (np.arange(size_px) - size_px // 2) * px
+        want_x = float(near["x"]) + offsets
+        want_y = float(near["y"]) - offsets
+        sub = ds[["embeddings", "scales"]].sel(time=year).reindex(
+            x=want_x,
+            y=want_y,
+            method="nearest",
+            tolerance=0.5 * px,
+            fill_value={"embeddings": np.int8(0), "scales": np.float32("nan")},
+        )
+        if progress:
+            from dask.diagnostics import ProgressBar
+
+            with ProgressBar():
+                scales = sub["scales"].values
+                emb_int8 = sub["embeddings"].values
+        else:
+            scales = sub["scales"].values
+            emb_int8 = sub["embeddings"].values
+        out = acc.dequantise(emb_int8, scales)
+
+        transform = rasterio.transform.Affine(
+            px, 0, want_x[0] - 0.5 * px, 0, -px, want_y[0] + 0.5 * px
+        )
+        self._log_patch_coverage(out, size_px)
+        return out, transform, acc.crs
+
+    def _read_patch_merged(
+        self,
+        zones: List[int],
+        target_crs: str,
+        lon: float,
+        lat: float,
+        year: int,
+        size_px: int,
+        px: float,
+        resampling: str,
+        progress: bool,
+    ) -> Tuple[np.ndarray, rasterio.transform.Affine, str]:
+        """Merge each zone's native pixels onto one patch-centred grid."""
+        ce, cn = _project(lon, lat, "EPSG:4326", target_crs)
+        # The point lands on the centre of pixel [size_px // 2, size_px // 2].
+        ox = ce - (size_px // 2 + 0.5) * px
+        oy = cn + (size_px // 2 + 0.5) * px
+        transform = rasterio.transform.Affine(px, 0, ox, 0, -px, oy)
+
+        # Densified outline: a straight edge curves in a zone's CRS, so
+        # corners alone under-cover mid-edge.
+        steps = np.linspace(0.0, size_px * px, 33)
+        outline = (
+            [(ox + s, oy) for s in steps]
+            + [(ox + s, oy - size_px * px) for s in steps]
+            + [(ox, oy - s) for s in steps]
+            + [(ox + size_px * px, oy - s) for s in steps]
+        )
+
+        gx, gy = np.meshgrid(
+            ox + (np.arange(size_px) + 0.5) * px,
+            oy - (np.arange(size_px) + 0.5) * px,
+        )
+        lons, _ = _transformer(target_crs, "EPSG:4326").transform(gx, gy)
+        owner = np.clip(np.floor((lons + 180.0) / 6.0).astype(int) + 1, 1, 60)
+
+        out = np.full((size_px, size_px, self.n_bands), np.nan, np.float32)
+        owned = np.zeros((size_px, size_px), dtype=bool)
+        spare = np.full_like(out, np.nan)
+        spared = np.zeros((size_px, size_px), dtype=bool)
+        for z in zones:
+            try:
+                acc = self.open_zone(zone=z).tessera
+            except KeyError as exc:
+                log.debug("read_patch: zone %d not in this store (%s)", z, exc)
+                continue
+            zone_pts = [_project(e, n, target_crs, acc.crs) for e, n in outline]
+            es = [c[0] for c in zone_pts]
+            ns = [c[1] for c in zone_pts]
+            pad = 2 * px
+            try:
+                mosaic, src_transform = acc.read_region(
+                    (min(es) - pad, min(ns) - pad, max(es) + pad, max(ns) + pad),
+                    year,
+                    progress=progress,
+                )
+            except IndexError:
+                continue  # the window misses everything this zone holds
+            if 0 in mosaic.shape[:2]:
+                continue
+            relocated = np.full((self.n_bands, size_px, size_px), np.nan, np.float32)
+            reproject(
+                source=mosaic.transpose(2, 0, 1),
+                destination=relocated,
+                src_transform=src_transform,
+                src_crs=acc.crs,
+                dst_transform=transform,
+                dst_crs=target_crs,
+                src_nodata=np.nan,
+                dst_nodata=np.nan,
+                resampling=Resampling[resampling],
+            )
+            relocated = relocated.transpose(1, 2, 0)
+            valid = np.isfinite(relocated).any(axis=2)
+            mine = valid & (owner == z)
+            out[mine] = relocated[mine]
+            owned |= mine
+            extra = valid & (owner != z) & ~spared
+            spare[extra] = relocated[extra]
+            spared |= extra
+
+        fill = ~owned & spared
+        out[fill] = spare[fill]
+        self._log_patch_coverage(out, size_px)
+        return out, transform, target_crs
+
+    @staticmethod
+    def _log_patch_coverage(patch: np.ndarray, size_px: int) -> None:
+        fraction = float(np.isfinite(patch).any(axis=2).mean())
+        if fraction < 1.0:
+            log.warning(
+                "read_patch: %.1f%% of the %dx%d patch has no coverage (NaN)",
+                (1.0 - fraction) * 100.0,
+                size_px,
+                size_px,
+            )

--- a/tests/store_check.py
+++ b/tests/store_check.py
@@ -7,19 +7,26 @@ for water, ``+inf`` for never written — so the suite stays offline and fast.
 Prints one ``ok - <name>`` line per check and exits non-zero if any failed.
 """
 
+import logging
 import sys
 
 import numpy as np
 import xarray as xr
+
+# Expected warnings (NaN-padded patches) must not reach cram's output.
+logging.getLogger("geotessera.store").setLevel(logging.ERROR)
 
 from geotessera.store import (
     NODATA,
     OUTSIDE,
     VALID,
     WATER,
+    GeoTesseraZarr,
+    _patch_crs,
     _resolve_zone,
     _seam_neighbours,
     _zone_for_lon,
+    _zones_spanned,
 )
 
 FAILED = []
@@ -184,6 +191,139 @@ check(
         np.isnan(watery.tessera.sample_at(float(watery.x[2]), float(watery.y[2]), 2024))
     ),
 )
+
+# ---------------------------------------------------------------------------
+# Patch reads (read_patch)
+# ---------------------------------------------------------------------------
+
+from pyproj import Transformer  # noqa: E402  (import here keeps the header light)
+
+
+def _fake_store(zone_datasets, n_bands=4):
+    """A GeoTesseraZarr with its zone cache pre-filled — no store opened."""
+    gt = GeoTesseraZarr.__new__(GeoTesseraZarr)
+    gt.url = "fake://"
+    gt.model_version = ""
+    gt.build_version = ""
+    gt.n_bands = n_bands
+    gt.years = [2024]
+    gt._cache = dict(zone_datasets)
+    return gt
+
+
+# Zone enumeration walks the ring the short way round.
+check("a patch inside one zone spans one zone", _zones_spanned([2.0, 2.5], 2.2) == [31])
+check(
+    "a patch across a seam spans both zones",
+    _zones_spanned([-0.01, 0.01], 0.0) == [30, 31],
+)
+check(
+    "a patch across the antimeridian wraps 60 to 1",
+    _zones_spanned([179.97, -179.97], 179.99) == [60, 1],
+)
+
+# The patch-centred CRS puts its false easting on the patch itself.
+_to_patch = Transformer.from_crs("EPSG:4326", _patch_crs(0.5, 52.0), always_xy=True)
+_pe, _pn = _to_patch.transform(0.5, 52.0)
+check("the patch CRS centres its meridian on the patch", abs(_pe - 500000.0) < 1e-3)
+_to_south = Transformer.from_crs("EPSG:4326", _patch_crs(0.5, -30.0), always_xy=True)
+check(
+    "a southern patch gets the southern false northing",
+    _to_south.transform(0.5, -30.0)[1] > 5_000_000,
+)
+
+# -- Native fast path: one zone, pure slice, no resampling ------------------
+
+flat = _fake_zone(np.full((12, 12), np.float32(0.05)))
+_to_wgs = Transformer.from_crs(flat.attrs["proj:code"], "EPSG:4326", always_xy=True)
+_clon, _clat = _to_wgs.transform(float(flat.x[6]), float(flat.y[6]))
+gt_one = _fake_store({_zone_for_lon(_clon): flat})
+
+patch, transform, crs = gt_one.read_patch(_clon, _clat, 2024, 6)
+check("a one-zone patch has the exact shape asked for", patch.shape == (6, 6, 4))
+check("a one-zone patch keeps the zone's own CRS", crs == flat.attrs["proj:code"])
+check(
+    "a one-zone patch holds native values, unresampled",
+    np.allclose(patch, np.array([1, 2, 3, 4]) * 0.05, atol=1e-6),
+)
+# The transform must place the patch centre within half a pixel of the point.
+_ce, _cn = transform * (3, 3)  # centre pixel's corner
+check(
+    "the native grid lands within half a pixel of the requested centre",
+    abs(_ce + 5.0 - float(flat.x[6])) <= 5.0 and abs(_cn - 5.0 - float(flat.y[6])) <= 5.0,
+)
+
+# A patch larger than the zone's data is NaN-padded, never truncated.
+patch, transform, crs = gt_one.read_patch(_clon, _clat, 2024, 20)
+inside = np.isfinite(patch).any(axis=2)
+check("an over-size patch keeps its shape and pads with NaN", patch.shape == (20, 20, 4))
+check(
+    "the padding surrounds intact native data",
+    0 < inside.sum() == 144 and np.allclose(
+        patch[inside], np.tile(np.array([1, 2, 3, 4]) * 0.05, (144, 1)), atol=1e-6
+    ),
+)
+
+# -- Merge path: a patch straddling the utm30/utm31 seam --------------------
+
+
+def _seam_zone(epsg, west_of_seam, lat=52.0, px=10.0, h=140, w=110, shift_px=0):
+    """A fake zone whose data stops at the lon=0 seam, like real tiles do.
+
+    ``shift_px`` moves the data edge east: overhang past the seam for the
+    western zone, a gap after it for the eastern one.
+    """
+    to_utm = Transformer.from_crs("EPSG:4326", f"EPSG:{epsg}", always_xy=True)
+    seam_e, seam_n = to_utm.transform(0.0, lat)
+    if west_of_seam:
+        ox, width, scale = seam_e - w * px, w + shift_px, np.float32(0.05)
+    else:
+        ox, width, scale = seam_e + shift_px * px, w, np.float32(0.07)
+    oy = seam_n + h * px / 2
+    return _fake_zone(np.full((h, width), scale), epsg=epsg, px=px, ox=ox, oy=oy)
+
+
+gt_seam = _fake_store({30: _seam_zone(32630, True), 31: _seam_zone(32631, False)})
+patch, transform, crs = gt_seam.read_patch(0.0, 52.0, 2024, 64)
+
+check("a seam patch has the exact shape asked for", patch.shape == (64, 64, 4))
+check("a seam patch comes back in a patch-centred CRS", "+proj=tmerc" in crs)
+coverage = np.isfinite(patch).any(axis=2).mean()
+check("a seam patch is covered from both zones", coverage > 0.98)
+check(
+    "west of the seam the western zone's values survive relocation",
+    np.allclose(patch[32, 5], np.array([1, 2, 3, 4]) * 0.05, atol=1e-6),
+)
+check(
+    "east of the seam the eastern zone's values survive relocation",
+    np.allclose(patch[32, 58], np.array([1, 2, 3, 4]) * 0.07, atol=1e-6),
+)
+# Both paths centre the requested point on pixel [size // 2, size // 2].
+_ce, _cn = Transformer.from_crs("EPSG:4326", crs, always_xy=True).transform(0.0, 52.0)
+_pe, _pn = transform * (32 + 0.5, 32 + 0.5)
+check(
+    "the merged grid centres the requested point on its centre pixel",
+    abs(_pe - _ce) < 1e-6 and abs(_pn - _cn) < 1e-6,
+)
+
+# Zone 30's data overhangs 5 px past the seam; zone 31's starts 3 px after it.
+gt_overlap = _fake_store(
+    {30: _seam_zone(32630, True, shift_px=5), 31: _seam_zone(32631, False, shift_px=3)}
+)
+patch, transform, crs = gt_overlap.read_patch(0.0, 52.0, 2024, 64)
+check(
+    "a sliver the owner lacks is filled by its neighbour",
+    np.allclose(patch[32, 33], np.array([1, 2, 3, 4]) * 0.05, atol=1e-6),
+)
+check(
+    "where zones overlap the owning zone wins",
+    np.allclose(patch[32, 36], np.array([1, 2, 3, 4]) * 0.07, atol=1e-6),
+)
+
+# Pinning dst_crs forces one shared grid even within a single zone.
+patch, transform, crs = gt_one.read_patch(_clon, _clat, 2024, 6, dst_crs="EPSG:3857")
+check("an explicit dst_crs is honoured", crs == "EPSG:3857" and patch.shape == (6, 6, 4))
+
 
 if FAILED:
     print(f"{len(FAILED)} check(s) failed", file=sys.stderr)


### PR DESCRIPTION
A patch within one UTM zone is sliced from the native grid unresampled.

One crossing a zone boundary is merged onto a patch-centred transverse Mercator grid with nearest-neighbour resampling, and `dst_crs=` pins any other output CRS. 

`read_region` now warns when its bbox crosses a zone boundary.