### PR TITLE
Fix URL resolution and improve error handling for GeoTesseraZarr

### DIFF
--- a/geotessera/registry.py
+++ b/geotessera/registry.py
@@ -508,9 +508,13 @@ def zarr_store_url(version: str) -> str:
     version's default variant, or an explicit store path such as
     ``"v2-2B-L~beta1"``.
     """
-    _, norm = _parse_dataset_version(version)
+    version_path, norm = _parse_dataset_version(version)
     if norm in VERSION_DEFAULT_VARIANTS:
-        version = dataset_path(norm, default_variant(norm))
+        variant = default_variant(norm)
+        if norm == "1.1":
+            version = version_path
+        else:
+            version = dataset_path(norm, variant)
     return f"{TESSERA_MIRROR_URL}/zarr/{version}"
 
 

--- a/geotessera/store.py
+++ b/geotessera/store.py
@@ -823,7 +823,20 @@ class GeoTesseraZarr:
         self._store = zarr_store(
             store_url, cache_dir=cache_dir, cache_max_size=cache_max_size
         )
-        root = zarr.open_group(self._store, mode="r")
+        try:
+            root = zarr.open_group(self._store, mode="r")
+        except (zarr.errors.GroupNotFoundError, zarr.errors.ArrayNotFoundError, KeyError) as e:
+            from .registry import KNOWN_DATASETS
+            
+            available = ", ".join(sorted({f"v{v}" for v, _, d in KNOWN_DATASETS if d}))
+            raise ValueError(
+                f"Failed to open zarr store at {self.url!r}. "
+                f"The store may not exist or the URL may be incorrect.\n"
+                f"Known versions: {available}. "
+                f"Use zarr_store_url() to generate correct store URLs, e.g., "
+                f"zarr_store_url('v1') or zarr_store_url('v2')."
+            ) from e
+        
         self._root = root
         root_attrs = dict(root.attrs)
         self.model_version: str = root_attrs.get("geoemb:model", "")

--- a/tests/store_check.py
+++ b/tests/store_check.py
@@ -529,9 +529,23 @@ from geotessera.registry import zarr_store_url  # noqa: E402
 check(
     "version names resolve to their store path",
     zarr_store_url("v1").endswith("/zarr/v1")
+    and zarr_store_url("v1.1").endswith("/zarr/v1.1")
     and zarr_store_url("v2").endswith("/zarr/v2-2B-L~beta1")
     and zarr_store_url("v2-2B-L~beta1").endswith("/zarr/v2-2B-L~beta1"),
 )
+
+# Test invalid store URL
+try:
+    GeoTesseraZarr("https://data.source.coop/tessera/tessera/zarr/v123")
+    check("invalid store URL raises helpful error", False)
+except ValueError as e:
+    msg = str(e)
+    check(
+        "invalid store URL raises helpful error",
+        "Failed to open zarr store" in msg
+        and "Known versions:" in msg
+        and "zarr_store_url()" in msg,
+    )
 
 # ---------------------------------------------------------------------------
 # Persistent cache keying (zarr_store cache_dir)


### PR DESCRIPTION
- Updated `zarr_store_url` to handle the `"1.1"` version differently, ensuring that it maps directly to its own path rather than to a default variant, while other versions still resolve to their default variants as before.
- In `GeoTesseraZarr.__init__`, added a try/except block to catch errors when opening a Zarr store fails. The new error message lists known dataset versions and suggests using `zarr_store_url()` for generating correct URLs, making it easier for users to diagnose and fix mistakes.
- Expanded tests in `tests/store_check.py` to verify that `zarr_store_url("v1.1")` resolves correctly and that attempting to open an invalid store URL raises the improved, helpful error message.

closes #393 